### PR TITLE
Perf: Skip allocations for Isolinear.Effect.none

### DIFF
--- a/src/Effect.re
+++ b/src/Effect.re
@@ -1,57 +1,66 @@
 type dispatchFunction('a) = 'a => unit;
 
 type effect('a) = {
-  getName: (int) => string,
+  getName: int => string,
   f: dispatchFunction('a) => unit,
 };
 
 type t('a) = option(effect('a));
 
-let _namePrinter = (name) => (indentLevel) => {
+let _namePrinter = (name, indentLevel) => {
   String.make(indentLevel, ' ') ++ name;
 };
 
-let create = (~name: string, f: unit => unit) => Some({getName: _namePrinter(name), f: _ => f()});
+let getName = (v: t('a)) =>
+  switch (v) {
+  | None => "(None)"
+  | Some(v) => v.getName(0)
+  };
 
-let createWithDispatch = (~name: string, f: dispatchFunction('a) => unit) => Some({
-  getName: _namePrinter(name),
-  f,
-});
+let create = (~name: string, f: unit => unit) =>
+  Some({getName: _namePrinter(name), f: _ => f()});
+
+let createWithDispatch = (~name: string, f: dispatchFunction('a) => unit) =>
+  Some({getName: _namePrinter(name), f});
 
 let none: t('a) = None;
 
 let run = (effect: t('a), dispatch: dispatchFunction('a)) => {
   switch (effect) {
   | None => ()
-  | Some(effect) => effect.f(dispatch);
-  }
+  | Some(effect) => effect.f(dispatch)
+  };
 };
 
 let batch = (effects: list(t('a))) => {
-  let effects = effects
-    |> List.filter(e => e != None);
+  let effects = effects |> List.filter(e => e != None);
 
   let execute = dispatch => {
     List.iter(e => run(e, dispatch), effects);
   };
 
-  let getName = (indentLevel) => {
-     let start = String.make(indentLevel, ' ') ++ "Batch" ++ ":";
+  let getName = indentLevel => {
+    let start = String.make(indentLevel, ' ') ++ "Batch" ++ ":";
 
-     start ++ List.fold_left((prev, curr) => {
-        switch (curr) {
-        | None => prev
-        | Some(curr) =>
-          let newName = curr.getName(indentLevel + 1) ++ "\n";
-          prev ++ newName;
-        };
-     }, "\n", effects);
+    start
+    ++ List.fold_left(
+         (prev, curr) => {
+           switch (curr) {
+           | None => prev
+           | Some(curr) =>
+             let newName = curr.getName(indentLevel + 1) ++ "\n";
+             prev ++ newName;
+           }
+         },
+         "\n",
+         effects,
+       );
   };
 
   switch (effects) {
   | [] => None
-  | v => Some({getName, f: execute });
-  }
+  | v => Some({getName, f: execute})
+  };
 };
 
 /* let batch: (~name: string, List(t)) => Effect.t; */

--- a/src/Effect.rei
+++ b/src/Effect.rei
@@ -1,0 +1,13 @@
+type dispatchFunction('a) = 'a => unit;
+
+type t('a);
+
+let create: (~name: string, unit => unit) => t('a);
+
+let createWithDispatch: (~name: string, dispatchFunction('a) => unit) => t('a);
+
+let none: t('a);
+
+let run: (t('a), dispatchFunction('a)) => unit;
+
+let batch: (list(t('a))) => t('a);

--- a/src/Effect.rei
+++ b/src/Effect.rei
@@ -1,13 +1,16 @@
-type dispatchFunction('a) = 'a => unit;
-
-type t('a);
-
-let create: (~name: string, unit => unit) => t('a);
-
-let createWithDispatch: (~name: string, dispatchFunction('a) => unit) => t('a);
-
-let none: t('a);
-
-let run: (t('a), dispatchFunction('a)) => unit;
-
-let batch: (list(t('a))) => t('a);
+type dispatchFunction('a) = 'a => unit;
+
+type t('a);
+
+let create: (~name: string, unit => unit) => t('a);
+
+let createWithDispatch:
+  (~name: string, dispatchFunction('a) => unit) => t('a);
+
+let getName: t('a) => string;
+
+let none: t('a);
+
+let run: (t('a), dispatchFunction('a)) => unit;
+
+let batch: list(t('a)) => t('a);


### PR DESCRIPTION
- Make `Isolinear.Effect.none` not require allocations
- Improve logging for effects, so it can actually be usable in Onivim 2