### PR TITLE
Fix internal type equality and dependencies, add public interface + cleanup

### DIFF
--- a/src/Effect.rei
+++ b/src/Effect.rei
@@ -1,18 +1,13 @@
-type dispatchFunction('a) = 'a => unit;
+type dispatcher('msg) = 'msg => unit;
 
-type t('a);
+type t('msg);
 
-let create: (~name: string, unit => unit) => t('a);
+let create: (~name: string, unit => unit) => t('msg);
+let createWithDispatch: (~name: string, dispatcher('msg) => unit) => t('msg);
 
-let createWithDispatch:
-  (~name: string, dispatchFunction('a) => unit) => t('a);
-
-let getName: t('a) => string;
-
-let none: t('a);
-
-let run: (t('a), dispatchFunction('a)) => unit;
-
-let batch: list(t('a)) => t('a);
-
+let none: t('msg);
+let batch: list(t('msg)) => t('msg);
 let map: ('a => 'b, t('a)) => t('b);
+
+let name: t('msg) => string;
+let run: (t('msg), dispatcher('msg)) => unit;

--- a/src/Isolinear.re
+++ b/src/Isolinear.re
@@ -7,6 +7,6 @@ module Updater = Updater;
 module Sub = Sub;
 module Store = Store;
 
-module Internal = {
+module Testing = {
   module SubscriptionRunner = SubscriptionRunner;
 };

--- a/src/Isolinear.re
+++ b/src/Isolinear.re
@@ -1,3 +1,6 @@
+type dispatcher('msg) = 'msg => unit;
+type unsubscribe = unit => unit;
+
 module Effect = Effect;
 module Store = Store;
 module Stream = Stream;

--- a/src/Isolinear.re
+++ b/src/Isolinear.re
@@ -1,14 +1,12 @@
 type dispatcher('msg) = 'msg => unit;
 type unsubscribe = unit => unit;
 
-module Effect = Effect;
-module Store = Store;
 module Stream = Stream;
+module Effect = Effect;
 module Updater = Updater;
-
 module Sub = Sub;
+module Store = Store;
 
 module Internal = {
-  module Sub = Sub;
   module SubscriptionRunner = SubscriptionRunner;
 };

--- a/src/Isolinear.rei
+++ b/src/Isolinear.rei
@@ -38,7 +38,7 @@ module Sub: {
   let map: ('a => 'b, t('a)) => t('b);
   let none: t('msg);
 
-  module type Sub = {
+  module type S = {
     type params;
     type msg;
 
@@ -64,11 +64,11 @@ module Sub: {
 
   module Make:
     (ConfigInfo: Config) =>
-     Sub with type msg = ConfigInfo.msg and type params = ConfigInfo.params;
+     S with type msg = ConfigInfo.msg and type params = ConfigInfo.params;
 };
 
 module Store: {
-  module type Store = {
+  module type S = {
     type msg;
     type model;
 
@@ -103,7 +103,7 @@ module Store: {
         let subscriptions: model => Sub.t(msg);
       },
     ) =>
-     Store with type msg = Config.msg and type model = Config.model;
+     S with type msg = Config.msg and type model = Config.model;
 };
 
 module Internal: {

--- a/src/Isolinear.rei
+++ b/src/Isolinear.rei
@@ -47,7 +47,7 @@ module Sub: {
     let create: params => t(msg);
   };
 
-  module type Config = {
+  module type Provider = {
     type params;
     type msg;
 
@@ -64,8 +64,8 @@ module Sub: {
   };
 
   module Make:
-    (Config: Config) =>
-     S with type msg = Config.msg and type params = Config.params;
+    (Provider: Provider) =>
+     S with type msg = Provider.msg and type params = Provider.params;
 };
 
 module Store: {

--- a/src/Isolinear.rei
+++ b/src/Isolinear.rei
@@ -4,11 +4,11 @@ type unsubscribe = unit => unit;
 module Stream: {
   type t('msg);
 
-  let ofDispatch: (dispatcher('msg) => unit) => t('msg);
   let create: unit => (t('msg), dispatcher('msg));
+
   let subscribe: (t('msg), dispatcher('msg)) => unsubscribe;
-  let map: (t('a), 'a => option('b)) => t('b);
   let connect: (dispatcher('msg), t('msg)) => unsubscribe;
+  let map: (t('a), 'a => option('b)) => t('b);
 };
 
 module Effect: {
@@ -17,11 +17,13 @@ module Effect: {
   let create: (~name: string, unit => unit) => t('a);
   let createWithDispatch:
     (~name: string, dispatcher('msg) => unit) => t('msg);
-  let getName: t(_) => string;
+
   let none: t(_);
-  let run: (t('msg), dispatcher('msg)) => unit;
   let batch: list(t('msg)) => t('msg);
   let map: ('a => 'b, t('a)) => t('b);
+
+  let name: t(_) => string;
+  let run: (t('msg), dispatcher('msg)) => unit;
 };
 
 module Updater: {
@@ -34,9 +36,9 @@ module Updater: {
 module Sub: {
   type t('msg);
 
+  let none: t('msg);
   let batch: list(t('msg)) => t('msg);
   let map: ('a => 'b, t('a)) => t('b);
-  let none: t('msg);
 
   module type S = {
     type params;
@@ -62,8 +64,8 @@ module Sub: {
   };
 
   module Make:
-    (ConfigInfo: Config) =>
-     S with type msg = ConfigInfo.msg and type params = ConfigInfo.params;
+    (Config: Config) =>
+     S with type msg = Config.msg and type params = Config.params;
 };
 
 module Store: {
@@ -108,10 +110,10 @@ module Store: {
 module Internal: {
   module SubscriptionRunner: {
     module Make:
-      (RunnerConfig: {type msg;}) =>
+      (Config: {type msg;}) =>
        {
         type t;
-        type msg = RunnerConfig.msg;
+        type msg = Config.msg;
 
         let empty: t;
         let run: (~dispatch: msg => unit, ~sub: Sub.t(msg), t) => t;

--- a/src/Isolinear.rei
+++ b/src/Isolinear.rei
@@ -1,4 +1,15 @@
-module Stream = Stream;
+module Stream: {
+  type sendFunc('a) = 'a => unit;
+  type streamFunc('a) = sendFunc('a) => unit;
+  type unsubscribeFunc = unit => unit;
+  type t('a);
+
+  let ofDispatch: streamFunc('a) => t('a);
+  let create: unit => (t('a), 'a => unit);
+  let subscribe: (t('a), sendFunc('a)) => unsubscribeFunc;
+  let map: (t('a), 'a => option('b)) => t('b);
+  let connect: ('action => unit, t('action)) => unsubscribeFunc;
+};
 
 module Effect: {
   type dispatchFunction('a) = 'a => unit;

--- a/src/Isolinear.rei
+++ b/src/Isolinear.rei
@@ -8,7 +8,7 @@ module Stream: {
 
   let subscribe: (t('msg), dispatcher('msg)) => unsubscribe;
   let connect: (dispatcher('msg), t('msg)) => unsubscribe;
-  let map: (t('a), 'a => option('b)) => t('b);
+  let filterMap: (t('a), 'a => option('b)) => t('b);
 };
 
 module Effect: {

--- a/src/Isolinear.rei
+++ b/src/Isolinear.rei
@@ -52,9 +52,8 @@ module Sub: {
     // State that is carried by the subscription while it is active
     type state;
 
-    let subscriptionName: string;
-
-    let getUniqueId: params => string;
+    let name: string;
+    let id: params => string;
 
     let init: (~params: params, ~dispatch: msg => unit) => state;
     let update:

--- a/src/Isolinear.rei
+++ b/src/Isolinear.rei
@@ -1,5 +1,4 @@
 module Effect = Effect;
-module Store = Store;
 module Stream = Stream;
 module Updater = Updater;
 
@@ -41,7 +40,55 @@ module Sub: {
   let none: t('msg);
 };
 
+module Store: {
+  module type Store = {
+    type msg;
+    type model;
+
+    let updater: Updater.t(msg, model);
+    let subscriptions: model => Sub.t(msg);
+
+    type unsubscribe = unit => unit;
+
+    let getModel: unit => model;
+    let dispatch: msg => unit;
+
+    let onBeforeMsg: (msg => unit) => unsubscribe;
+    let onModelChanged: (model => unit) => unsubscribe;
+    let onAfterMsg: ((msg, model) => unit) => unsubscribe;
+
+    let onBeforeEffectRan: (Effect.t(msg) => unit) => unsubscribe;
+    let onPendingEffect: (unit => unit) => unsubscribe;
+    let onAfterEffectRan: (Effect.t(msg) => unit) => unsubscribe;
+
+    let hasPendingEffects: unit => bool;
+    let runPendingEffects: unit => unit;
+
+    module Deprecated: {let getStoreStream: unit => Stream.t((model, msg));};
+  };
+
+  module Make:
+    (
+      Config: {
+        type msg;
+        type model;
+
+        let initial: model;
+        let updater: Updater.t(msg, model);
+        let subscriptions: model => Sub.t(msg);
+      },
+    ) =>
+    Store with type msg = Config.msg and type model = Config.model;
+};
+
 module Internal: {
-  module Sub = Sub;
-  module SubscriptionRunner = SubscriptionRunner;
+  module SubscriptionRunner: {
+    module Make: (RunnerConfig: {type msg;}) => {
+      type t;
+      type msg = RunnerConfig.msg;
+
+      let empty: t;
+      let run: (~dispatch: msg => unit, ~sub: Sub.t(msg), t) => t;
+    };
+  };
 };

--- a/src/Isolinear.rei
+++ b/src/Isolinear.rei
@@ -107,7 +107,7 @@ module Store: {
      S with type msg = Config.msg and type model = Config.model;
 };
 
-module Internal: {
+module Testing: {
   module SubscriptionRunner: {
     module Make:
       (Config: {type msg;}) =>

--- a/src/Isolinear.rei
+++ b/src/Isolinear.rei
@@ -1,6 +1,25 @@
-module Effect = Effect;
 module Stream = Stream;
-module Updater = Updater;
+
+module Effect: {
+  type dispatchFunction('a) = 'a => unit;
+  type t('a);
+
+  let create: (~name: string, unit => unit) => t('a);
+  let createWithDispatch:
+    (~name: string, dispatchFunction('a) => unit) => t('a);
+  let getName: t('a) => string;
+  let none: t('a);
+  let run: (t('a), dispatchFunction('a)) => unit;
+  let batch: list(t('a)) => t('a);
+  let map: ('a => 'b, t('a)) => t('b);
+};
+
+module Updater: {
+  type t('msg, 'model) = ('model, 'msg) => ('model, Effect.t('msg));
+
+  let ofReducer: (('model, 'msg) => 'model) => t('msg, 'model);
+  let combine: list(t('msg, 'model)) => t('msg, 'model);
+};
 
 module Sub: {
   module type Config = {

--- a/src/Isolinear.rei
+++ b/src/Isolinear.rei
@@ -78,17 +78,19 @@ module Store: {
         let subscriptions: model => Sub.t(msg);
       },
     ) =>
-    Store with type msg = Config.msg and type model = Config.model;
+     Store with type msg = Config.msg and type model = Config.model;
 };
 
 module Internal: {
   module SubscriptionRunner: {
-    module Make: (RunnerConfig: {type msg;}) => {
-      type t;
-      type msg = RunnerConfig.msg;
+    module Make:
+      (RunnerConfig: {type msg;}) =>
+       {
+        type t;
+        type msg = RunnerConfig.msg;
 
-      let empty: t;
-      let run: (~dispatch: msg => unit, ~sub: Sub.t(msg), t) => t;
-    };
+        let empty: t;
+        let run: (~dispatch: msg => unit, ~sub: Sub.t(msg), t) => t;
+      };
   };
 };

--- a/src/Pipe.re
+++ b/src/Pipe.re
@@ -1,0 +1,10 @@
+type t('a) = ref(option('a));
+
+let create = () => ref(None);
+
+let send = (inPipe, outPipe, data) => {
+  inPipe := Some(data); // send
+  let received = outPipe^; // receive
+  inPipe := None; // reset
+  received; // return
+};

--- a/src/Pipe.rei
+++ b/src/Pipe.rei
@@ -3,9 +3,9 @@
 // existentials where it's impossible to prove that the two values of the same
 // type actually are of the same type. The pipe allows the value to "coerced"
 // from one type to another in a type-safe manner. If the type is not the same,
-// the "input" and "output" pipes also cannot be the same, and hence pasing a
+// the "input" and "output" pipes also cannot be the same, and hence passing a
 // value into the "input" pipe will not see anything come out of the "output".
-// 'send' will then simply reutnr `None`.
+// 'send' will then simply return `None`.
 
 type t('data);
 

--- a/src/Pipe.rei
+++ b/src/Pipe.rei
@@ -1,4 +1,4 @@
-// Borrowed from ReactMini - the "pipe" (our term) is a mechanism for
+// Borrowed from ReactMini's `handedOffInstance` - the "pipe" is a mechanism for
 // communicating between instances sharing the same pipe, in the presence of
 // existentials where it's impossible to prove that the two values of the same
 // type actually are of the same type. The pipe allows the value to "coerced"

--- a/src/Pipe.rei
+++ b/src/Pipe.rei
@@ -1,0 +1,13 @@
+// Borrowed from ReactMini - the "pipe" (our term) is a mechanism for
+// communicating between instances sharing the same pipe, in the presence of
+// existentials where it's impossible to prove that the two values of the same
+// type actually are of the same type. The pipe allows the value to "coerced"
+// from one type to another in a type-safe manner. If the type is not the same,
+// the "input" and "output" pipes also cannot be the same, and hence pasing a
+// value into the "input" pipe will not see anything come out of the "output".
+// 'send' will then simply reutnr `None`.
+
+type t('data);
+
+let create: unit => t('data);
+let send: (t('a), t('b), 'a) => option('b);

--- a/src/Store.re
+++ b/src/Store.re
@@ -1,11 +1,11 @@
+type unsubscribe = unit => unit;
+
 module type Store = {
   type msg;
   type model;
 
-  let updater: Updater.t(msg, model);
+  let updater: Updater.t(model, msg);
   let subscriptions: model => Sub.t(msg);
-
-  type unsubscribe = unit => unit;
 
   let getModel: unit => model;
   let dispatch: msg => unit;
@@ -31,7 +31,7 @@ module Make =
            type model;
 
            let initial: model;
-           let updater: Updater.t(msg, model);
+           let updater: Updater.t(model, msg);
            let subscriptions: model => Sub.t(msg);
          },
        ) => {
@@ -56,7 +56,7 @@ module Make =
     pendingEffectDispatch: unit => unit,
     latestModel: ref(model),
     pendingEffects: ref(list(Effect.t(msg))),
-    updater: Updater.t(msg, model),
+    updater: Updater.t(model, msg),
     // Legacy store stream for compatibility with old API
     legacyStoreDispatch: ((model, msg)) => unit,
     legacyStoreStream: Stream.t((model, msg)),

--- a/src/Store.re
+++ b/src/Store.re
@@ -99,8 +99,6 @@ module Make =
     legacyStoreStream,
   };
 
-  type unsubscribe = unit => unit;
-
   let getModel = () => store.latestModel^;
 
   let rec dispatch = (msg: msg) => {
@@ -185,13 +183,11 @@ module Make =
   let onBeforeEffectRan = Stream.subscribe(store.beforeEffectStream);
   let onAfterEffectRan = Stream.subscribe(store.afterEffectStream);
 
-  let onModelChanged = subscription => {
+  let onModelChanged = subscription =>
     Stream.subscribe(store.modelChangedStream, subscription);
-  };
 
-  let onPendingEffect = subscription => {
+  let onPendingEffect = subscription =>
     Stream.subscribe(store.pendingEffectStream, subscription);
-  };
 
   module Deprecated = {
     let getStoreStream = () => {

--- a/src/Store.re
+++ b/src/Store.re
@@ -1,6 +1,6 @@
 type unsubscribe = unit => unit;
 
-module type Store = {
+module type S = {
   type msg;
   type model;
 

--- a/src/Store.rei
+++ b/src/Store.rei
@@ -1,11 +1,11 @@
+type unsubscribe = unit => unit;
+
 module type Store = {
   type msg;
   type model;
 
-  let updater: Updater.t(msg, model);
+  let updater: Updater.t(model, msg);
   let subscriptions: model => Sub.t(msg);
-
-  type unsubscribe = unit => unit;
 
   let getModel: unit => model;
   let dispatch: msg => unit;
@@ -31,7 +31,7 @@ module Make:
       type model;
 
       let initial: model;
-      let updater: Updater.t(msg, model);
+      let updater: Updater.t(model, msg);
       let subscriptions: model => Sub.t(msg);
     },
   ) =>

--- a/src/Store.rei
+++ b/src/Store.rei
@@ -1,6 +1,6 @@
 type unsubscribe = unit => unit;
 
-module type Store = {
+module type S = {
   type msg;
   type model;
 
@@ -35,4 +35,4 @@ module Make:
       let subscriptions: model => Sub.t(msg);
     },
   ) =>
-   Store with type msg = Config.msg and type model = Config.model;
+   S with type msg = Config.msg and type model = Config.model;

--- a/src/Stream.re
+++ b/src/Stream.re
@@ -1,13 +1,6 @@
-type sendFunc('a) = 'a => unit;
-/* type complete = unit => unit; */
-
-type streamFunc('a) = sendFunc('a) => unit;
-
-type unsubscribeFunc = unit => unit;
-
-type subscriber('a) = {
+type subscriber('msg) = {
   id: int,
-  onValue: sendFunc('a),
+  onValue: 'msg => unit,
   /* onComplete: complete, */
 };
 
@@ -16,7 +9,7 @@ type t('a) = {
   subscribers: ref(list(subscriber('a))),
 };
 
-let ofDispatch = (f: streamFunc('a)) => {
+let ofDispatch = f => {
   let subscribers: ref(list(subscriber('a))) = ref([]);
 
   let onValue = (v: 'a) => {
@@ -43,7 +36,7 @@ let create = () => {
   (stream, dispatch);
 };
 
-let subscribe = (v: t('a), f: sendFunc('a)) => {
+let subscribe = (v, f) => {
   let id = v.lastSubscriberId^ + 1;
   v.lastSubscriberId := id;
 
@@ -65,7 +58,7 @@ let map = (v: t('a), f: 'a => option('b)) => {
       | Some(v) => send(v)
       }
     )
-    |> (ignore: unsubscribeFunc => unit)
+    |> (ignore: (unit => unit) => unit)
   );
 };
 

--- a/src/Stream.re
+++ b/src/Stream.re
@@ -45,8 +45,7 @@ let subscribe = (stream, onValue) => {
 let connect = (dispatch: 'msg => unit, stream: t('msg)) =>
   subscribe(stream, dispatch);
 
-// TODO: This should be called `filterMap`
-let map = (stream, f: 'a => option('b)) => {
+let filterMap = (stream, f: 'a => option('b)) => {
   ofDispatch(send =>
     subscribe(stream, msg => f(msg) |> Option.iter(send))
     |> (ignore: (unit => unit) => unit)

--- a/src/Stream.re
+++ b/src/Stream.re
@@ -4,17 +4,15 @@ type subscriber('msg) = {
   /* onComplete: complete, */
 };
 
-type t('a) = {
+type t('msg) = {
   lastSubscriberId: ref(int),
-  subscribers: ref(list(subscriber('a))),
+  subscribers: ref(list(subscriber('msg))),
 };
 
 let ofDispatch = f => {
-  let subscribers: ref(list(subscriber('a))) = ref([]);
+  let subscribers: ref(list(subscriber('msg))) = ref([]);
 
-  let onValue = (v: 'a) => {
-    List.iter(s => s.onValue(v), subscribers^);
-  };
+  let onValue = value => List.iter(sub => sub.onValue(value), subscribers^);
 
   f(onValue);
 
@@ -22,46 +20,35 @@ let ofDispatch = f => {
 };
 
 let create = () => {
-  let _dispatchFunction = ref(None);
+  let dispatcher = ref(None);
 
-  let stream = ofDispatch(dispatch => _dispatchFunction := Some(dispatch));
+  let stream = ofDispatch(dispatch => dispatcher := Some(dispatch));
 
-  let dispatch = v => {
-    switch (_dispatchFunction^) {
-    | Some(f) => f(v)
-    | None => ()
-    };
-  };
+  let dispatch = msg => Option.iter(dispatch => dispatch(msg), dispatcher^);
 
   (stream, dispatch);
 };
 
-let subscribe = (v, f) => {
-  let id = v.lastSubscriberId^ + 1;
-  v.lastSubscriberId := id;
+let subscribe = (stream, onValue) => {
+  incr(stream.lastSubscriberId);
+  let id = stream.lastSubscriberId^;
 
-  let subscriber = {id, onValue: f};
-  v.subscribers := [subscriber, ...v.subscribers^];
+  stream.subscribers := [{id, onValue}, ...stream.subscribers^];
 
   let unsubscribe = () =>
-    v.subscribers := List.filter(sub => sub.id != id, v.subscribers^);
+    stream.subscribers :=
+      List.filter(sub => sub.id != id, stream.subscribers^);
 
   unsubscribe;
 };
 
+let connect = (dispatch: 'msg => unit, stream: t('msg)) =>
+  subscribe(stream, dispatch);
+
 // TODO: This should be called `filterMap`
-let map = (v: t('a), f: 'a => option('b)) => {
+let map = (stream, f: 'a => option('b)) => {
   ofDispatch(send =>
-    subscribe(v, x =>
-      switch (f(x)) {
-      | None => ()
-      | Some(v) => send(v)
-      }
-    )
+    subscribe(stream, msg => f(msg) |> Option.iter(send))
     |> (ignore: (unit => unit) => unit)
   );
-};
-
-let connect = (dispatch: 'action => unit, stream: t('action)) => {
-  subscribe(stream, v => dispatch(v));
 };

--- a/src/Sub.re
+++ b/src/Sub.re
@@ -56,7 +56,7 @@ let rec map: ('a => 'b, t('a)) => t('b) =
     switch (sub) {
     | NoSubscription => NoSubscription
     | Subscription(sub, orig) =>
-      let newMapFunction = x => f(orig(x));
+      let newMapFunction = msg => f(orig(msg));
       Subscription(sub, newMapFunction);
     | SubscriptionBatch(subs) => SubscriptionBatch(List.map(map(f), subs))
     };
@@ -69,18 +69,16 @@ module type S = {
   let create: params => t(msg);
 };
 
-module Make = (ConfigInfo: Config) => {
-  type params = ConfigInfo.params;
-  type msg = ConfigInfo.msg;
+module Make = (Config: Config) => {
+  type params = Config.params;
+  type msg = Config.msg;
 
   let handedOffInstance = ref(None);
 
-  let mapper = a => a;
-
   let create = params => {
     Subscription(
-      {handedOffInstance, config: (module ConfigInfo), params, state: None},
-      mapper,
+      {handedOffInstance, config: (module Config), params, state: None},
+      Fun.id,
     );
   };
 };

--- a/src/Sub.re
+++ b/src/Sub.re
@@ -5,9 +5,8 @@ module type Config = {
   // State that is carried by the subscription while it is active
   type state;
 
-  let subscriptionName: string;
-
-  let getUniqueId: params => string;
+  let name: string;
+  let id: params => string;
 
   let init: (~params: params, ~dispatch: msg => unit) => state;
   let update:

--- a/src/Sub.re
+++ b/src/Sub.re
@@ -1,4 +1,4 @@
-module type Config = {
+module type Provider = {
   type params;
   type msg;
 
@@ -14,13 +14,13 @@ module type Config = {
   let dispose: (~params: params, ~state: state) => unit;
 };
 
-type config('params, 'msg, 'state) = (module Config with
-                                         type msg = 'msg and
-                                         type params = 'params and
-                                         type state = 'state);
+type provider('params, 'msg, 'state) = (module Provider with
+                                           type msg = 'msg and
+                                           type params = 'params and
+                                           type state = 'state);
 
 type subscription('params, 'msg, 'state) = {
-  config: config('params, 'msg, 'state),
+  provider: provider('params, 'msg, 'state),
   params: 'params,
   state: option('state),
   // This is the same trick used in ReactMini -
@@ -69,15 +69,15 @@ module type S = {
   let create: params => t(msg);
 };
 
-module Make = (Config: Config) => {
-  type params = Config.params;
-  type msg = Config.msg;
+module Make = (Provider: Provider) => {
+  type params = Provider.params;
+  type msg = Provider.msg;
 
   let handedOffInstance = ref(None);
 
   let create = params => {
     Subscription(
-      {handedOffInstance, config: (module Config), params, state: None},
+      {handedOffInstance, provider: (module Provider), params, state: None},
       Fun.id,
     );
   };

--- a/src/Sub.re
+++ b/src/Sub.re
@@ -63,7 +63,7 @@ let rec map: ('a => 'b, t('a)) => t('b) =
     };
   };
 
-module type Sub = {
+module type S = {
   type params;
   type msg;
 

--- a/src/SubscriptionRunner.re
+++ b/src/SubscriptionRunner.re
@@ -12,7 +12,7 @@ module Make = (RunnerConfig: {type msg;}) => {
     switch (subscription) {
     | NoSubscription => "__isolinear__nosubscription__"
     | Subscription({params, state, config: (module Config)}, _) =>
-      Config.subscriptionName ++ "$" ++ Config.getUniqueId(params)
+      Config.name ++ "$" ++ Config.id(params)
     | SubscriptionBatch(_) => "__isolinear__batch__"
     };
   };

--- a/src/SubscriptionRunner.re
+++ b/src/SubscriptionRunner.re
@@ -4,10 +4,9 @@ module Make = (RunnerConfig: {type msg;}) => {
   //type t('msg) = subscription('msg);
 
   type msg = RunnerConfig.msg;
-  type t = Hashtbl.t(string, Sub.t(RunnerConfig.msg));
+  type t = Hashtbl.t(string, Sub.t(msg));
 
-  let empty: Hashtbl.t(string, Sub.t(RunnerConfig.msg)) =
-    Hashtbl.create(0);
+  let empty: t = Hashtbl.create(0);
 
   let getSubscriptionName = (subscription: Sub.t(msg)) => {
     switch (subscription) {

--- a/src/Updater.re
+++ b/src/Updater.re
@@ -1,8 +1,6 @@
 type t('model, 'msg) = ('model, 'msg) => ('model, Effect.t('msg));
 
-let ofReducer = (reducer, model, msg) => {
-  (reducer(model, msg), Effect.none);
-};
+let ofReducer = (reducer, model, msg) => (reducer(model, msg), Effect.none);
 
 let combine = (updaters, state, action) => {
   let (newState, effects) =
@@ -16,7 +14,7 @@ let combine = (updaters, state, action) => {
       updaters,
     );
 
-  let effects = effects |> List.filter(e => e !== Effect.none) |> List.rev;
+  let effects = effects |> List.filter(eff => eff !== Effect.none) |> List.rev;
 
   (newState, Effect.batch(effects));
 };

--- a/src/Updater.re
+++ b/src/Updater.re
@@ -1,9 +1,7 @@
-type t('msg, 'model) = ('model, 'msg) => ('model, Effect.t('msg));
+type t('model, 'msg) = ('model, 'msg) => ('model, Effect.t('msg));
 
-type reducer('msg, 'model) = ('model, 'msg) => 'model;
-
-let ofReducer = (v: reducer('msg, 'model), s, a) => {
-  (v(s, a), Effect.none);
+let ofReducer = (reducer, model, msg) => {
+  (reducer(model, msg), Effect.none);
 };
 
 let combine = (updaters, state, action) => {

--- a/src/Updater.rei
+++ b/src/Updater.rei
@@ -1,5 +1,4 @@
-type t('msg, 'model) = ('model, 'msg) => ('model, Effect.t('msg));
+type t('model, 'msg) = ('model, 'msg) => ('model, Effect.t('msg));
 
-let ofReducer: (('model, 'msg) => 'model) => t('msg, 'model);
-
-let combine: list(t('msg, 'model)) => t('msg, 'model);
+let ofReducer: (('model, 'msg) => 'model) => t('model, 'msg);
+let combine: list(t('model, 'msg)) => t('model, 'msg);

--- a/test/StoreTests.re
+++ b/test/StoreTests.re
@@ -17,8 +17,8 @@ module TestSubscription =
 
     type state = unit;
 
-    let subscriptionName = "testSubscription";
-    let getUniqueId = _ => "unique";
+    let name = "testSubscription";
+    let id = _ => "unique";
 
     let init = (~params as _, ~dispatch as _) => {
       incr(startCount);

--- a/test/StoreTests.re
+++ b/test/StoreTests.re
@@ -1,7 +1,7 @@
 open TestFramework;
 
 module Store = Isolinear.Store;
-module Sub = Isolinear.Internal.Sub;
+module Sub = Isolinear.Sub;
 module Effect = Isolinear.Effect;
 
 type testActions =

--- a/test/SubscriptionRunnerTests.re
+++ b/test/SubscriptionRunnerTests.re
@@ -38,9 +38,9 @@ module TestSubscription =
 
     type state = list(testState);
 
-    let subscriptionName = "TestSubscription";
+    let name = "TestSubscription";
 
-    let getUniqueId = params => params |> string_of_int;
+    let id = params => params |> string_of_int;
 
     let init = (~params, ~dispatch) => {
       dispatch(Init(params));

--- a/test/SubscriptionRunnerTests.re
+++ b/test/SubscriptionRunnerTests.re
@@ -1,7 +1,7 @@
 open TestFramework;
 
 module Sub = Isolinear.Sub;
-module SubscriptionRunner = Isolinear.Internal.SubscriptionRunner;
+module SubscriptionRunner = Isolinear.Testing.SubscriptionRunner;
 
 type testState =
   | Init(int)

--- a/test/SubscriptionRunnerTests.re
+++ b/test/SubscriptionRunnerTests.re
@@ -1,6 +1,6 @@
 open TestFramework;
 
-module Sub = Isolinear.Internal.Sub;
+module Sub = Isolinear.Sub;
 module SubscriptionRunner = Isolinear.Internal.SubscriptionRunner;
 
 type testState =

--- a/test/SubscriptionRunnerTests.re
+++ b/test/SubscriptionRunnerTests.re
@@ -131,7 +131,7 @@ describe("SubscriptionRunner", ({describe, _}) => {
 
       expect.equal(allActions^ |> List.rev, [Init2(1)]);
 
-      let _state = Runner2.run(~dispatch, ~sub=sub1, state);
+      let _: Runner2.t = Runner2.run(~dispatch, ~sub=sub1, state);
 
       expect.equal(allActions^ |> List.rev, [Init2(1), Update2(1)]);
     })


### PR DESCRIPTION
The internal `Store` interface was what messed it up I think. I just coped it verbatim into `Isolinear.rei`, but that makes the `Sub.t` it refers to the external one, instead of the internal one.

I'd like to clean this up a bit more though, if you'll hold off on merging this for a little bit (until tomorrow, actually, since it's late here.).