### PR TITLE
bump macOS CI VMs to 10.14

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ jobs:
   displayName: 'Hygiene Checks'
   timeoutInMinutes: 0
   pool:
-    vmImage: 'macOS 10.13'
+    vmImage: 'macOS 10.14'
 
   variables:
     STAGING_DIRECTORY: $(Build.StagingDirectory)
@@ -47,7 +47,7 @@ jobs:
 - job: MacOS
   timeoutInMinutes: 0
   pool:
-    vmImage: 'macOS 10.13'
+    vmImage: 'macOS 10.14'
 
   variables:
     STAGING_DIRECTORY: $(Build.StagingDirectory)


### PR DESCRIPTION
Because 10.13 is no longer supported on Azure