### PR TITLE
fix(subscription): No dispatch after dispose

### DIFF
--- a/src/Sub.re
+++ b/src/Sub.re
@@ -23,7 +23,6 @@ type subscription('params, 'msg, 'state) = {
   // This is to handle the case where a subscription holds on to the `dispatch` function
   // - either in `update` or `init`, and tries to dispatch when the subscription is no longer available.
   latch: ref(bool),
-
   provider: provider('params, 'msg, 'state),
   params: 'params,
   state: option('state),
@@ -86,7 +85,13 @@ module Make = (Provider: Provider) => {
 
   let create = params => {
     Subscription(
-      {latch: ref(false), pipe, provider: (module Provider), params, state: None},
+      {
+        latch: ref(false),
+        pipe,
+        provider: (module Provider),
+        params,
+        state: None,
+      },
       Fun.id,
     );
   };

--- a/src/SubscriptionRunner.re
+++ b/src/SubscriptionRunner.re
@@ -21,7 +21,9 @@ module Make = (Config: {type msg;}) => {
     switch (subscription) {
     | NoSubscription => ()
 
-    | Subscription({provider: (module Provider), params, state}, _) =>
+    | Subscription({provider: (module Provider), params, state, latch}, _) =>
+      latch := false;
+      
       switch (state) {
       // Config was never actually created, so no need to dispose
       | None => ()
@@ -39,14 +41,15 @@ module Make = (Config: {type msg;}) => {
     | NoSubscription => NoSubscription
 
     | Subscription(
-        {provider: (module Provider), params, state, pipe},
+        {latch, provider: (module Provider), params, state, pipe},
         mapper,
       ) =>
+      latch := true;
       let state =
-        Provider.init(~params, ~dispatch=msg => dispatch(mapper(msg)));
+        Provider.init(~params, ~dispatch=msg => if (latch^) {dispatch(mapper(msg)) });
 
       Subscription(
-        {provider: (module Provider), params, state: Some(state), pipe},
+        {latch, provider: (module Provider), params, state: Some(state), pipe},
         mapper,
       );
 
@@ -77,12 +80,15 @@ module Make = (Config: {type msg;}) => {
       switch (Pipe.send(oldData.pipe, newData.pipe, oldData.state)) {
       | Some(Some(oldState)) =>
         // These types do match! And we know about the old state
+        let latch = oldData.latch;
         let newState =
           Provider.update(
             ~params=newData.params, ~state=oldState, ~dispatch=msg =>
-            dispatch(newMapper(msg))
+            if (latch^) {
+              dispatch(newMapper(msg))
+            }
           );
-        Subscription({...newData, state: Some(newState)}, newMapper);
+        Subscription({...newData, latch, state: Some(newState)}, newMapper);
 
       | None
       | Some(None) =>

--- a/src/SubscriptionRunner.re
+++ b/src/SubscriptionRunner.re
@@ -23,12 +23,12 @@ module Make = (Config: {type msg;}) => {
 
     | Subscription({provider: (module Provider), params, state, latch}, _) =>
       latch := false;
-      
+
       switch (state) {
       // Config was never actually created, so no need to dispose
       | None => ()
       | Some(state) => Provider.dispose(~params, ~state)
-      }
+      };
 
     // This should never be hit, because the batches are removed
     // prior to reconciliation
@@ -46,10 +46,20 @@ module Make = (Config: {type msg;}) => {
       ) =>
       latch := true;
       let state =
-        Provider.init(~params, ~dispatch=msg => if (latch^) {dispatch(mapper(msg)) });
+        Provider.init(~params, ~dispatch=msg =>
+          if (latch^) {
+            dispatch(mapper(msg));
+          }
+        );
 
       Subscription(
-        {latch, provider: (module Provider), params, state: Some(state), pipe},
+        {
+          latch,
+          provider: (module Provider),
+          params,
+          state: Some(state),
+          pipe,
+        },
         mapper,
       );
 
@@ -85,7 +95,7 @@ module Make = (Config: {type msg;}) => {
           Provider.update(
             ~params=newData.params, ~state=oldState, ~dispatch=msg =>
             if (latch^) {
-              dispatch(newMapper(msg))
+              dispatch(newMapper(msg));
             }
           );
         Subscription({...newData, latch, state: Some(newState)}, newMapper);

--- a/test/SubscriptionRunnerTests.re
+++ b/test/SubscriptionRunnerTests.re
@@ -87,16 +87,16 @@ module SubscriptionThatHoldsOnToDispatch =
 
 describe("SubscriptionRunner", ({describe, _}) => {
   describe("dispose", ({test, _}) => {
-    test("dispatch called after subscription is gone is a no-op", ({expect, _}) => {
+    test(
+      "dispatch called after subscription is gone is a no-op", ({expect, _}) => {
       let actions: ref(list(testState)) = ref([]);
       let dispatch = action => {
-        actions := [action, ...actions^]
+        actions := [action, ...actions^];
       };
       let sub = SubscriptionThatHoldsOnToDispatch.create(1);
       let runner = Runner.run(~dispatch, ~sub, Runner.empty);
 
-      globalDispatch^
-      |> Option.iter(dispatch => dispatch(Init(1)));
+      globalDispatch^ |> Option.iter(dispatch => dispatch(Init(1)));
 
       // Not disposed... should've gotten an action!
       expect.equal(actions^, [Init(1)]);
@@ -105,14 +105,13 @@ describe("SubscriptionRunner", ({describe, _}) => {
 
       // Dispose of sub
       let _ = Runner.run(~dispatch, ~sub=Isolinear.Sub.none, runner);
-      
-      globalDispatch^
-      |> Option.iter(dispatch => dispatch(Init(2)));
-      
+
+      globalDispatch^ |> Option.iter(dispatch => dispatch(Init(2)));
+
       expect.equal(actions^, []);
-    });
+    })
   });
-  
+
   describe("subscribe", ({test, _}) => {
     test("init is called", ({expect, _}) => {
       let lastAction: ref(option(testState)) = ref(None);

--- a/test/SubscriptionRunnerTests.re
+++ b/test/SubscriptionRunnerTests.re
@@ -58,7 +58,61 @@ module TestSubscription =
     };
   });
 
+let globalDispatch = ref(None);
+
+module SubscriptionThatHoldsOnToDispatch =
+  Sub.Make({
+    type params = int;
+    type msg = testState;
+
+    type state = unit;
+
+    let name = "SubscriptionThatHoldsOnToDispatch";
+
+    let id = params => params |> string_of_int;
+
+    let init = (~params, ~dispatch) => {
+      globalDispatch := Some(dispatch);
+      ();
+    };
+
+    let update = (~params as _, ~state as _, ~dispatch as _) => {
+      ();
+    };
+
+    let dispose = (~params as _, ~state as _) => {
+      ();
+    };
+  });
+
 describe("SubscriptionRunner", ({describe, _}) => {
+  describe("dispose", ({test, _}) => {
+    test("dispatch called after subscription is gone is a no-op", ({expect, _}) => {
+      let actions: ref(list(testState)) = ref([]);
+      let dispatch = action => {
+        actions := [action, ...actions^]
+      };
+      let sub = SubscriptionThatHoldsOnToDispatch.create(1);
+      let runner = Runner.run(~dispatch, ~sub, Runner.empty);
+
+      globalDispatch^
+      |> Option.iter(dispatch => dispatch(Init(1)));
+
+      // Not disposed... should've gotten an action!
+      expect.equal(actions^, [Init(1)]);
+
+      actions := [];
+
+      // Dispose of sub
+      let _ = Runner.run(~dispatch, ~sub=Isolinear.Sub.none, runner);
+      
+      globalDispatch^
+      |> Option.iter(dispatch => dispatch(Init(2)));
+      
+      expect.equal(actions^, []);
+    });
+  });
+  
   describe("subscribe", ({test, _}) => {
     test("init is called", ({expect, _}) => {
       let lastAction: ref(option(testState)) = ref(None);


### PR DESCRIPTION
__Issue:__

It's common for subscriptions in Onivim 2 to 'hold' the `dispatch`, like subscriptions that kick off an async operation, for example:

https://github.com/onivim/oni2/blob/3314264b65856b90640455c5573e93f946e00ed0/src/Service/Exthost/Service_Exthost.re#L617

However, the subscription might get disposed while the request is in-flight, and in that case, the `dispatch` function will be called, even though the subscription is not valid. This breaks the mental-model of subscriptions providing messages only when they are active.

As a work-around, in Onivim, there's a `Latch` that turns off dispatch after the subscription is disposed - but makes sense to just bake that in here. If there's a case where we are depending on a message to be dispatched _after_ a subscription is disposed, it's a logical bug.

__Fix:__ Add a ref that is carried along the lifecycle of the subscription - when disposed, we'll switch it to `false` so that future dispatches no longer occur.

